### PR TITLE
feat: skip when from SSR

### DIFF
--- a/packages/dev-server-hmr/src/hmrPlugin.js
+++ b/packages/dev-server-hmr/src/hmrPlugin.js
@@ -110,7 +110,7 @@ function hmrPlugin(pluginConfig) {
       }
     },
     async transform(code, id, options) {
-      if (shouldSkipHmr) return
+      if (shouldSkipHmr || options?.ssr) return
 
       const filePath = id
       if (


### PR DESCRIPTION
Otherwise we get an `window` is undefined.

Can be tested with: https://github.com/JulianCataldo/vite-lit-ssr